### PR TITLE
fixing bug in catching failed future

### DIFF
--- a/src/main/scala/adc/tutorial/scala/akka/step6/Echo6Supervisor.scala
+++ b/src/main/scala/adc/tutorial/scala/akka/step6/Echo6Supervisor.scala
@@ -21,7 +21,7 @@ class Echo6Supervisor(service: StorageService) extends Actor with ActorLogging {
     case fm: FailedMessageException =>
       val message = Message(s"could not process message because ${fm.reason.getMessage}")
       log.info(message.content, fm)
-      fm.sender ! message
+      fm.askedBy ! message
       badMessages = badMessages + 1
       Stop
 

--- a/src/main/scala/adc/tutorial/scala/akka/step6/StorageService.scala
+++ b/src/main/scala/adc/tutorial/scala/akka/step6/StorageService.scala
@@ -5,6 +5,7 @@ import java.io.{BufferedWriter, File, FileWriter}
 import Echo6.{ContentWritten, StorageLength}
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 
 class StorageService(val fileName: String) {
@@ -34,6 +35,10 @@ class StorageService(val fileName: String) {
     withFile[Boolean](fileName) { f => {
       f.delete()
     }}
+  }
+
+  def forceFailure(): Future[Unit] = Future {
+    throw PersistenceException(destination=fileName, reason=new Exception("expected"))
   }
 }
 

--- a/src/main/scala/adc/tutorial/scala/akka/step6/UnknownMessageException.scala
+++ b/src/main/scala/adc/tutorial/scala/akka/step6/UnknownMessageException.scala
@@ -4,6 +4,6 @@ import akka.actor.ActorRef
 
 case class PersistenceException(destination: String, reason: Throwable) extends Exception(s"could not persist to $destination", reason)
 
-case class FailedMessageException(sender: ActorRef, reason: Throwable) extends Exception(s"could not process message", reason)
+case class FailedMessageException(askedBy: ActorRef, reason: Throwable) extends Exception(s"could not process message", reason)
 
 case class UnknownMessageException(askedBy: ActorRef, messageType: String) extends Exception(s"received unknown message of type $messageType") { }


### PR DESCRIPTION
What changed:

The StorageService throws a PersistenceException and the Echo6 actor was attempting to respond to this as a message in its receive block.

Thrown exceptions in the pipe pattern show up in the recevier (that is the destination of  the 'pipeTo' as a Status.Failure with the cause returning the actual exception thrown

This fix modifies the Echo6 actor to recevie the Status.Failure and then look for the PersistenceException in the cause.  It also updates the unit test to verify
